### PR TITLE
downgrade java version to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <java.version>1.8</java.version>
+        <java.version>1.6</java.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>${scala.binary.version}.8</scala.version>
 


### PR DESCRIPTION
scala 2.11 runs fine on jdk 1.6, but when plugin is compiled with 1.8 it can't run on lower java any more, fixes #7 