### PR TITLE
Add support for restricted fields in class generation for compatibility with Scala 2.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ You can override the following variables in the plugin configuration:
 * Boolean to allow recursion over the specified **sourceDirectory**
 * Defaults to **false**
 
+#### limitedNumberOfFieldsInCaseClasses
+* Boolean to restrict case class generation for compatibility with scala 2.10
+* Defaults to **false**
+
 #### Example
 
 To override the **sourceDirectory** and **outputDirectory**, use
@@ -121,7 +125,7 @@ To override the **sourceDirectory** and **outputDirectory**, use
 </plugins>
 ```
 
-To override the **sourceDirectory**, **outputDirectory** and recurse over **sourceDirectory**, use
+To override the **sourceDirectory**, **outputDirectory**, recurse over **sourceDirectory**, and restrict generated class fields to be compatible with Scala 2.10 use
 
 ```xml
 <plugins>
@@ -140,6 +144,7 @@ To override the **sourceDirectory**, **outputDirectory** and recurse over **sour
             <sourceDirectory>src/main/resources/avro</sourceDirectory>
             <outputDirectory>target/generated-sources</outputDirectory>
             <recursive>true</recursive>
+            <limitedNumberOfFieldsInCaseClasses>true</limitedNumberOfFieldsInCaseClasses>>
         </configuration>
     </plugin>
 </plugins>
@@ -154,6 +159,7 @@ Scala code.
 ## Contributors
 * [robbruce](https://github.com/robbruce)
 * [Eugene Platonov](https://github.com/jozic)
+* [Jason Bowman](https://github.com/sini)
 
 ## License
 The Avrohugger Maven Plugin is released under version 2.0 of the [Apache License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
@@ -36,6 +36,9 @@ public class GeneratorMojo extends AbstractMojo {
     @Parameter(property = "recursive", defaultValue = "false", required = true)
     private Boolean recursive;
 
+    @Parameter(property = "limitedNumberOfFieldsInCaseClasses", defaultValue = "false", required = true)
+    private Boolean limitedNumberOfFieldsInCaseClasses;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         String sourceDirectoryPath = sourceDirectory.getAbsolutePath();
@@ -47,6 +50,6 @@ public class GeneratorMojo extends AbstractMojo {
         getLog().info("Generating Scala files for schemas in " + sourceDirectoryPath + " to " + outputDirectoryPath);
 
         AvrohuggerGenerator generator = new AvrohuggerGenerator();
-        generator.generateScalaFiles(sourceDirectory, outputDirectoryPath, getLog(), recursive);
+        generator.generateScalaFiles(sourceDirectory, outputDirectoryPath, getLog(), recursive, limitedNumberOfFieldsInCaseClasses);
     }
 }

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -27,8 +27,8 @@ import org.apache.maven.plugin.logging.Log
 import scala.collection.mutable.ListBuffer
 
 class AvrohuggerGenerator {
-  def generateScalaFiles(inputDirectory: File, outputDirectory: String, log: Log, recursive: Boolean): Unit = {
-    val generator = new Generator(SpecificRecord)
+  def generateScalaFiles(inputDirectory: File, outputDirectory: String, log: Log, recursive: Boolean, limitedNumberOfFieldsInCaseClasses: Boolean): Unit = {
+    val generator = new Generator(SpecificRecord, restrictedFieldNumber = limitedNumberOfFieldsInCaseClasses)
 
     listFiles(inputDirectory, recursive).foreach { schemaFile =>
       log.info(s"Generating Scala files for ${schemaFile.getAbsolutePath}")

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -46,7 +46,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         File expectedRecord = inputDirectory.resolve("expected/Record.scala").toFile();
         File actualRecords = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala").toFile();
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false);
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false);
 
         assertTrue("Generated Scala file does not match expected one", FileUtils.contentEquals(expectedRecord, actualRecords));
     }
@@ -61,7 +61,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         File expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala").toFile();
         File actualSubRecords = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala").toFile();
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true);
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false);
 
         assertTrue("Generated Scala Record file does not match expected one", FileUtils.contentEquals(expectedRecord, actualRecords));
         assertTrue("Generated Scala SubRecord file does not match expected one", FileUtils.contentEquals(expectedSubRecord, actualSubRecords));


### PR DESCRIPTION
Scala 2.10 case classes are limited to 22 fields. AVRO schema definitions exceeding this number of fields fail to generate compatible case classes. Exposing this flag allows users to optionally generate classes instead of case classes for records that exceed 22 fields.