### PR TITLE
add the namespace mapping capability of avrohugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ You can override the following variables in the plugin configuration:
 
 #### namespaceMapping
 * Map namespace in Avro files to custom package name in generated scala files
-* Defaults to **null** (Namespace is not modified)
+* Defaults to **Empty List** (Namespace is not modified)
 
 #### Example
 
@@ -178,10 +178,10 @@ To override the **namespaceMapping** of Avro protocols under the `com.example.pa
         </executions>
         <configuration>
             <namespaceMapping>
-                <mapping>
+                <Mapping>
                     <from>com.example.packagename</from>
-                    <to>com.example.packagenamechanged</to>
-                </mapping>
+                    <to>com.example.packagenamenew.subchange</to>
+                </Mapping>
             </namespaceMapping>
         </configuration>
     </plugin>

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ You can override the following variables in the plugin configuration:
 * Format for source code generation
 * Defaults to **SPECIFIC_RECORD**
 
+#### namespaceMapping
+* Map namespace in Avro files to custom package name in generated scala files
+* Defaults to **null** (Namespace is not modified)
+
 #### Example
 
 To override the **sourceDirectory** and **outputDirectory**, use
@@ -152,6 +156,33 @@ To override the **sourceDirectory**, **outputDirectory**, recurse over **sourceD
             <outputDirectory>target/generated-sources</outputDirectory>
             <recursive>true</recursive>
             <limitedNumberOfFieldsInCaseClasses>true</limitedNumberOfFieldsInCaseClasses>>
+        </configuration>
+    </plugin>
+</plugins>
+```
+
+To override the **namespaceMapping** of Avro protocols under the `com.example.packagename` namespace to `com.example.packagenamechanged`
+
+```xml
+<plugins>
+    <plugin>
+        <groupId>at.makubi.maven.plugin</groupId>
+        <artifactId>avrohugger-maven-plugin</artifactId>
+        <executions>
+            <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                    <goal>generate-scala-sources</goal>
+                </goals>
+            </execution>
+        </executions>
+        <configuration>
+            <namespaceMapping>
+                <mapping>
+                    <from>com.example.packagename</from>
+                    <to>com.example.packagenamechanged</to>
+                </mapping>
+            </namespaceMapping>
         </configuration>
     </plugin>
 </plugins>

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
@@ -23,6 +23,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class GeneratorMojo extends AbstractMojo {
     private SourceGenerationFormat sourceGenerationFormat;
 
     @Parameter(property = "namespaceMapping")
-    private List<mapping> namespaceMapping;
+    private List<Mapping> namespaceMapping = new ArrayList<>();
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -58,13 +59,6 @@ public class GeneratorMojo extends AbstractMojo {
         String outputDirectoryPath = outputDirectory.getAbsolutePath();
         getLog().info("Generating Scala files for schemas in " + sourceDirectoryPath + " to " + outputDirectoryPath);
 
-        Map<String, String> nonNullNamespaceMapping = new HashMap<>();
-        if (namespaceMapping != null && !namespaceMapping.isEmpty()) {
-            for (int i = 0; i < namespaceMapping.size(); ++i) {
-                nonNullNamespaceMapping.put(namespaceMapping.get(i).from, namespaceMapping.get(i).to);
-            }
-        }
-
         AvrohuggerGenerator generator = new AvrohuggerGenerator();
         generator.generateScalaFiles(sourceDirectory,
                 outputDirectoryPath,
@@ -72,6 +66,6 @@ public class GeneratorMojo extends AbstractMojo {
                 recursive,
                 limitedNumberOfFieldsInCaseClasses,
                 sourceGenerationFormat,
-                nonNullNamespaceMapping);
+                namespaceMapping);
     }
 }

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/GeneratorMojo.java
@@ -23,6 +23,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Mojo(name = "generate-scala-sources")
 public class GeneratorMojo extends AbstractMojo {
@@ -42,6 +45,9 @@ public class GeneratorMojo extends AbstractMojo {
     @Parameter(property = "sourceGenerationFormat", defaultValue = Defaults.sourceGenerationFormat, required = true)
     private SourceGenerationFormat sourceGenerationFormat;
 
+    @Parameter(property = "namespaceMapping")
+    private List<mapping> namespaceMapping;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         String sourceDirectoryPath = sourceDirectory.getAbsolutePath();
@@ -52,7 +58,20 @@ public class GeneratorMojo extends AbstractMojo {
         String outputDirectoryPath = outputDirectory.getAbsolutePath();
         getLog().info("Generating Scala files for schemas in " + sourceDirectoryPath + " to " + outputDirectoryPath);
 
+        Map<String, String> nonNullNamespaceMapping = new HashMap<>();
+        if (namespaceMapping != null && !namespaceMapping.isEmpty()) {
+            for (int i = 0; i < namespaceMapping.size(); ++i) {
+                nonNullNamespaceMapping.put(namespaceMapping.get(i).from, namespaceMapping.get(i).to);
+            }
+        }
+
         AvrohuggerGenerator generator = new AvrohuggerGenerator();
-        generator.generateScalaFiles(sourceDirectory, outputDirectoryPath, getLog(), recursive, limitedNumberOfFieldsInCaseClasses, sourceGenerationFormat);
+        generator.generateScalaFiles(sourceDirectory,
+                outputDirectoryPath,
+                getLog(),
+                recursive,
+                limitedNumberOfFieldsInCaseClasses,
+                sourceGenerationFormat,
+                nonNullNamespaceMapping);
     }
 }

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/Mapping.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/Mapping.java
@@ -1,6 +1,6 @@
 package at.makubi.maven.plugin.avrohugger;
 
-public class mapping {
+public class Mapping {
     String from;
     String to;
 }

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/mapping.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/mapping.java
@@ -1,0 +1,6 @@
+package at.makubi.maven.plugin.avrohugger;
+
+public class mapping {
+    String from;
+    String to;
+}

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -24,7 +24,7 @@ import avrohugger.filesorter.{AvdlFileSorter, AvscFileSorter}
 import avrohugger.format.{Scavro, SpecificRecord, Standard}
 import org.apache.maven.plugin.logging.Log
 import java.util
-import collection.JavaConversions._
+import collection.JavaConverters._
 
 import scala.collection.mutable.ListBuffer
 
@@ -35,7 +35,7 @@ class AvrohuggerGenerator {
     recursive: Boolean,
     limitedNumberOfFieldsInCaseClasses: Boolean,
     sourceGenerationFormat: SourceGenerationFormat,
-    namespaceMappings: util.Map[String, String]
+    namespaceMappings: util.List[Mapping]
   ): Unit = {
     val sourceFormat = sourceGenerationFormat match {
       case SourceGenerationFormat.SCAVRO => Scavro
@@ -43,7 +43,9 @@ class AvrohuggerGenerator {
       case SourceGenerationFormat.STANDARD => Standard
     }
 
-    val generator = new Generator(sourceFormat, restrictedFieldNumber = limitedNumberOfFieldsInCaseClasses, avroScalaCustomNamespace = namespaceMappings.toMap)
+    val mappings = namespaceMappings.asScala.map { m => m.from -> m.to }.toMap
+
+    val generator = new Generator(sourceFormat, restrictedFieldNumber = limitedNumberOfFieldsInCaseClasses, avroScalaCustomNamespace = mappings)
 
     listFiles(inputDirectory, recursive).foreach { schemaFile =>
       log.info(s"Generating Scala files for ${schemaFile.getAbsolutePath}")

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -23,18 +23,27 @@ import avrohugger.Generator
 import avrohugger.filesorter.{AvdlFileSorter, AvscFileSorter}
 import avrohugger.format.{Scavro, SpecificRecord, Standard}
 import org.apache.maven.plugin.logging.Log
+import java.util
+import collection.JavaConversions._
 
 import scala.collection.mutable.ListBuffer
 
 class AvrohuggerGenerator {
-  def generateScalaFiles(inputDirectory: File, outputDirectory: String, log: Log, recursive: Boolean, limitedNumberOfFieldsInCaseClasses: Boolean, sourceGenerationFormat: SourceGenerationFormat): Unit = {
+  def generateScalaFiles(inputDirectory: File,
+    outputDirectory: String,
+    log: Log,
+    recursive: Boolean,
+    limitedNumberOfFieldsInCaseClasses: Boolean,
+    sourceGenerationFormat: SourceGenerationFormat,
+    namespaceMappings: util.Map[String, String]
+  ): Unit = {
     val sourceFormat = sourceGenerationFormat match {
       case SourceGenerationFormat.SCAVRO => Scavro
       case SourceGenerationFormat.SPECIFIC_RECORD => SpecificRecord
       case SourceGenerationFormat.STANDARD => Standard
     }
 
-    val generator = new Generator(sourceFormat, restrictedFieldNumber = limitedNumberOfFieldsInCaseClasses)
+    val generator = new Generator(sourceFormat, restrictedFieldNumber = limitedNumberOfFieldsInCaseClasses, avroScalaCustomNamespace = namespaceMappings.toMap)
 
     listFiles(inputDirectory, recursive).foreach { schemaFile =>
       log.info(s"Generating Scala files for ${schemaFile.getAbsolutePath}")

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -57,7 +57,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<String, String>emptyMap());
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
     }
@@ -72,7 +72,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala");
         Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<String, String>emptyMap());
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
         failTestIfFilesDiffer(expectedSubRecord, actualSubRecord);

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import static at.makubi.maven.plugin.avrohugger.TestHelper.failTestIfFilesDiffer;
 
@@ -56,7 +57,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD);
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<String, String>emptyMap());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
     }
@@ -71,7 +72,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala");
         Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD);
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<String, String>emptyMap());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
         failTestIfFilesDiffer(expectedSubRecord, actualSubRecord);

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/GeneratorMojoTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/GeneratorMojoTest.java
@@ -100,6 +100,7 @@ public class GeneratorMojoTest extends AbstractHarnessMojoTestCase {
         final Path apiAvdl = Paths.get("Api.avdl");
         final Path subApiAvdl = Paths.get("SubApi.avdl");
         final Path recordWith25FieldsAvdl = Paths.get("RecordWith25Fields.avdl");
+        final Path changedNamespaceAvdl = Paths.get("ChangedNamespace.avdl");
         final String testPomName = "pom-overwrite.xml";
 
         createDir(testAvroSourceDir);
@@ -114,6 +115,7 @@ public class GeneratorMojoTest extends AbstractHarnessMojoTestCase {
         Files.copy(testResourcesDir.resolve(apiAvdl), testAvroSourceDir.resolve(apiAvdl), StandardCopyOption.REPLACE_EXISTING);
         Files.copy(testResourcesDir.resolve(subApiAvdl), testAvroSourceSubDir.resolve(subApiAvdl), StandardCopyOption.REPLACE_EXISTING);
         Files.copy(testResourcesDir.resolve(recordWith25FieldsAvdl), testAvroSourceDir.resolve(recordWith25FieldsAvdl), StandardCopyOption.REPLACE_EXISTING);
+        Files.copy(testResourcesDir.resolve(changedNamespaceAvdl), testAvroSourceDir.resolve(changedNamespaceAvdl), StandardCopyOption.REPLACE_EXISTING);
 
         GeneratorMojo generatorMojo = (GeneratorMojo) lookupMojo("generate-scala-sources", getTestFile(pomPath.toString()));
         generatorMojo.execute();
@@ -127,6 +129,9 @@ public class GeneratorMojoTest extends AbstractHarnessMojoTestCase {
 
         // Test 'limitedNumberOfFieldsInCaseClasses'
         failTestIfFilesDiffer(overwriteTestResourcesDir.resolve("RecordWith25Fields.scala"), testRunnerProjectBuildDir.resolve(relativeOutputDirectory).resolve("at/makubi/maven/plugin/model/RecordWith25Fields.scala"));
+
+        // Test 'namespaceMapping'
+        failTestIfFilesDiffer(overwriteTestResourcesDir.resolve("NamespaceRecord.scala"), testRunnerProjectBuildDir.resolve(relativeOutputDirectory).resolve("at/makubi/maven/plugin/model/namespacechanged/subchange/NamespaceRecord.scala"));
     }
 
 }

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/ChangedNamespace.avdl
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/ChangedNamespace.avdl
@@ -1,0 +1,6 @@
+@namespace("at.makubi.maven.plugin.model.namespacetest")
+protocol NamespaceTest {
+  record NamespaceRecord {
+    string text;
+  }
+}

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/NamespaceRecord.scala
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/NamespaceRecord.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package at.makubi.maven.plugin.model.namespacechanged.subchange
+
+case class NamespaceRecord(text: String)

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/pom-overwrite.xml
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/pom-overwrite.xml
@@ -19,6 +19,12 @@
                     <recursive>true</recursive>
                     <limitedNumberOfFieldsInCaseClasses>true</limitedNumberOfFieldsInCaseClasses>
                     <sourceGenerationFormat>STANDARD</sourceGenerationFormat>
+                    <namespaceMapping>
+                        <Mapping>
+                            <from>at.makubi.maven.plugin.model.namespacetest</from>
+                            <to>at.makubi.maven.plugin.model.namespacechanged.subchange</to>
+                        </Mapping>
+                    </namespaceMapping>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Avro Hugger has the ability to change the namespace of the generated scala source files. 
https://github.com/julianpeeters/avrohugger#customizable-namespace-mapping

This PR exposes this mapping functionality.