### PR TITLE
Fix sorting algorithm for schema files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>at.makubi.maven.plugin</groupId>
     <artifactId>avrohugger-maven-plugin</artifactId>
-    <version>1.8</version>
+    <version>1.8-TTD</version>
     <packaging>maven-plugin</packaging>
 
     <name>Avrohugger Maven Plugin</name>
@@ -20,7 +20,7 @@
 
         <maven.plugin.api.version>3.8.1</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.6.1</maven.plugin.annotations.version>
-        <avrohugger.version>1.0.0-RC25</avrohugger.version>
+        <avrohugger.version>1.0.0-RC25-TTD</avrohugger.version>
         <junit.version>4.13.2</junit.version>
         <maven.plugin.testing.harness.version>3.3.0</maven.plugin.testing.harness.version>
         <commons.io.version>2.11.0</commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>at.makubi.maven.plugin</groupId>
     <artifactId>avrohugger-maven-plugin</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.8</version>
     <packaging>maven-plugin</packaging>
 
     <name>Avrohugger Maven Plugin</name>
@@ -14,13 +14,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <java.version>11</java.version>
-        <scala.binary.version>2.13</scala.binary.version>
-        <scala.version>2.13.6</scala.version>
+        <java.version>1.8</java.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.12.11</scala.version>
 
         <maven.plugin.api.version>3.8.1</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.6.1</maven.plugin.annotations.version>
-        <avrohugger.version>1.0.0-RC24</avrohugger.version>
+        <avrohugger.version>1.0.0-RC25</avrohugger.version>
         <junit.version>4.13.2</junit.version>
         <maven.plugin.testing.harness.version>3.3.0</maven.plugin.testing.harness.version>
         <commons.io.version>2.11.0</commons.io.version>

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -18,14 +18,13 @@ package at.makubi.maven.plugin.avrohugger
 
 import java.io.File
 import java.nio.file.{FileSystems, Path}
-
 import at.makubi.maven.plugin.avrohugger.Implicits._
 import avrohugger.Generator
 import avrohugger.filesorter.{AvdlFileSorter, AvscFileSorter}
 import avrohugger.format.{Scavro, SpecificRecord, Standard}
 import org.apache.maven.plugin.logging.Log
-import java.util
 
+import java.util
 import at.makubi.maven.plugin.avrohugger.typeoverride.TypeOverrides
 
 import scala.jdk.CollectionConverters._
@@ -33,15 +32,17 @@ import scala.collection.mutable.ListBuffer
 
 class AvrohuggerGenerator {
 
-  def generateScalaFiles(inputDirectory: File,
-                         outputDirectory: String,
-                         log: Log,
-                         recursive: Boolean,
-                         limitedNumberOfFieldsInCaseClasses: Boolean,
-                         sourceGenerationFormat: SourceGenerationFormat,
-                         namespaceMappings: util.List[Mapping],
-                         fileIncludes: java.util.List[FileInclude],
-                         typeOverrides: TypeOverrides): Unit = {
+  def generateScalaFiles(
+      inputDirectory: File,
+      outputDirectory: String,
+      log: Log,
+      recursive: Boolean,
+      limitedNumberOfFieldsInCaseClasses: Boolean,
+      sourceGenerationFormat: SourceGenerationFormat,
+      namespaceMappings: util.List[Mapping],
+      fileIncludes: java.util.List[FileInclude],
+      typeOverrides: TypeOverrides
+  ): Unit = {
     val filter = { pathname: File =>
       val filePathRelativeToInputDirectory = inputDirectory.toPath.relativize(pathname.toPath)
       log.debug(s"Path ${pathname.toString} relative to input directory ${inputDirectory.toString} is $filePathRelativeToInputDirectory")
@@ -84,27 +85,29 @@ class AvrohuggerGenerator {
       avroScalaCustomTypes = if (customTypes != sourceFormat.defaultTypes) Some(customTypes) else None
     )
 
-    listFiles(inputDirectory, recursive).filter(filter).foreach { schemaFile =>
+    sortSchemaFiles(listFiles(Seq(inputDirectory), recursive).filter(filter)).foreach { schemaFile =>
       log.info(s"Generating Scala files for ${schemaFile.getAbsolutePath}")
 
       generator.fileToFile(schemaFile, outputDirectory)
     }
   }
 
-  protected def listFiles(inputDirectory: File, recursive: Boolean): Seq[File] = {
-    val allFiles = inputDirectory.listFiles()
+  protected def listFiles(inputFiles: Seq[File], recursive: Boolean, accFiles: Seq[File] = Seq.empty): Seq[File] = {
+    val files = inputFiles.filter(_.isFile) ++: accFiles
+    val subFiles = inputFiles.filter(_.isDirectory).flatMap(_.listFiles())
+    if (recursive && subFiles.nonEmpty) listFiles(subFiles, recursive, files)
+    else files ++: subFiles.filter(_.isFile)
+  }
+
+  protected def sortSchemaFiles(files: Seq[File]): Seq[File] = {
     val schemaFiles = new ListBuffer[File]()
 
-    schemaFiles ++= AvdlFileSorter.sortSchemaFiles(allFiles.withSuffix(".avdl"))
-    schemaFiles ++= AvscFileSorter.sortSchemaFiles(allFiles.withSuffix(".avsc"))
-    schemaFiles ++= allFiles.withSuffix(".avpr")
-    schemaFiles ++= allFiles.withSuffix(".avro")
+    schemaFiles ++= AvdlFileSorter.sortSchemaFiles(files.withSuffix(".avdl"))
+    schemaFiles ++= AvscFileSorter.sortSchemaFiles(files.withSuffix(".avsc"))
+    schemaFiles ++= files.withSuffix(".avpr")
+    schemaFiles ++= files.withSuffix(".avro")
 
-    if (recursive) {
-      schemaFiles ++= allFiles.filter { _.isDirectory }.flatMap { listFiles(_, true) }
-    }
-
-    schemaFiles.toSeq
+    schemaFiles
   }
 
   protected def accept(filePathRelativeToInputDirectory: Path, fileInclude: FileInclude): Boolean = {

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -32,17 +32,15 @@ import scala.collection.mutable.ListBuffer
 
 class AvrohuggerGenerator {
 
-  def generateScalaFiles(
-      inputDirectory: File,
-      outputDirectory: String,
-      log: Log,
-      recursive: Boolean,
-      limitedNumberOfFieldsInCaseClasses: Boolean,
-      sourceGenerationFormat: SourceGenerationFormat,
-      namespaceMappings: util.List[Mapping],
-      fileIncludes: java.util.List[FileInclude],
-      typeOverrides: TypeOverrides
-  ): Unit = {
+  def generateScalaFiles(inputDirectory: File,
+                         outputDirectory: String,
+                         log: Log,
+                         recursive: Boolean,
+                         limitedNumberOfFieldsInCaseClasses: Boolean,
+                         sourceGenerationFormat: SourceGenerationFormat,
+                         namespaceMappings: util.List[Mapping],
+                         fileIncludes: java.util.List[FileInclude],
+                         typeOverrides: TypeOverrides): Unit = {
     val filter = { pathname: File =>
       val filePathRelativeToInputDirectory = inputDirectory.toPath.relativize(pathname.toPath)
       log.debug(s"Path ${pathname.toString} relative to input directory ${inputDirectory.toString} is $filePathRelativeToInputDirectory")

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
@@ -76,11 +76,9 @@ object Implicits {
     }
   }
 
-  implicit class FileArrayEnricher(files: Array[File]) {
+  implicit class FileArrayEnricher(files: Seq[File]) {
 
-    def withSuffix(suffix: String): Array[File] = {
-      files.filter(_.getName.endsWith(suffix))
-    }
+    def withSuffix(suffix: String): Seq[File] = files.filter(_.getName.endsWith(suffix))
   }
 
 }

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -41,9 +41,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         super.setUp();
 
         avrohuggerGenerator = new AvrohuggerGenerator();
-        outputDirectory = Files.createTempDirectory(
-                Paths.get(getBasedir()).resolve("target"),
-                AvrohuggerGeneratorTest.class.getCanonicalName());
+        outputDirectory = Files.createTempDirectory(Paths.get(getBasedir()).resolve("target"), AvrohuggerGeneratorTest.class.getCanonicalName());
     }
 
     @After
@@ -60,10 +58,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
 
-        avrohuggerGenerator.generateScalaFiles(
-                schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false,
-                SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(),
-                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(), Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
     }
@@ -93,9 +88,7 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala");
         Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false,
-                SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(),
-                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(), Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
         failTestIfFilesDiffer(expectedSubRecord, actualSubRecord);

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -41,7 +41,9 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         super.setUp();
 
         avrohuggerGenerator = new AvrohuggerGenerator();
-        outputDirectory = Files.createTempDirectory(Paths.get(getBasedir()).resolve("target"), AvrohuggerGeneratorTest.class.getCanonicalName());
+        outputDirectory = Files.createTempDirectory(
+                Paths.get(getBasedir()).resolve("target"),
+                AvrohuggerGeneratorTest.class.getCanonicalName());
     }
 
     @After
@@ -58,7 +60,25 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(), Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+        avrohuggerGenerator.generateScalaFiles(
+                schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false,
+                SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(),
+                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+
+        failTestIfFilesDiffer(expectedRecord, actualRecord);
+    }
+
+    public void testAvrohuggerGeneratorWithSort() throws IOException {
+        Path inputDirectory = Paths.get(getBasedir()).resolve("src/test/resources/unit/avrohugger-maven-plugin");
+        Path schemaDirectory = inputDirectory.resolve("standardSchema");
+
+        Path expectedRecord = inputDirectory.resolve("expected/ARecord.scala");
+        Path actualRecord = outputDirectory.resolve("com/test/ARecord/ARecord.scala");
+
+        avrohuggerGenerator.generateScalaFiles(
+                schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false,
+                SourceGenerationFormat.STANDARD, Collections.<Mapping>emptyList(),
+                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
     }
@@ -69,11 +89,13 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
 
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
-        
+
         Path expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala");
         Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
 
-        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(), Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false,
+                SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(),
+                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
 
         failTestIfFilesDiffer(expectedRecord, actualRecord);
         failTestIfFilesDiffer(expectedSubRecord, actualSubRecord);

--- a/src/test/resources/unit/avrohugger-maven-plugin/expected/ARecord.scala
+++ b/src/test/resources/unit/avrohugger-maven-plugin/expected/ARecord.scala
@@ -1,0 +1,4 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.test.ARecord
+
+final case class ARecord(GroupId: String = "", MediaCostCPMInUSD: Option[BigDecimal], SupplyVendor: Option[String])

--- a/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/a/ARecord.avsc
+++ b/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/a/ARecord.avsc
@@ -1,0 +1,30 @@
+{
+  "type": "record",
+  "name": "ARecord",
+  "namespace": "com.test.ARecord",
+  "fields": [
+    {
+      "name": "GroupId",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "name": "MediaCostCPMInUSD",
+      "aliases": ["WinningPriceCPMInBucks"],
+      "type": [
+        "null",
+        "com.test.MoneyDecimal"
+      ],
+      "tsvIndex": 5
+    },
+    {
+      "name": "SupplyVendor",
+      "aliases": ["SupplyVendorName"],
+      "type": [
+        "null",
+        "string"
+      ],
+      "tsvIndex": 6
+    }
+  ]
+}

--- a/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/b/MoneyDecimal.avsc
+++ b/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/b/MoneyDecimal.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "fixed",
+  "size": 12,
+  "namespace": "com.test",
+  "name": "MoneyDecimal",
+  "logicalType": "decimal",
+  "precision": 28,
+  "scale": 15
+}


### PR DESCRIPTION
Whole directory structure loaded first and then schema files are sorted according to dependencies and usage instead of doing it directory by directory.