### PR TITLE
Fix sorting algorithm

### DIFF
--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/FileListHelper.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/FileListHelper.scala
@@ -1,0 +1,22 @@
+package at.makubi.maven.plugin.avrohugger
+
+import java.io.File
+import scala.annotation.tailrec
+
+trait FileListHelper {
+  def listFiles(directory: File, recursive: Boolean): Seq[File]
+}
+
+class DefaultFileListHelper extends FileListHelper {
+
+  override def listFiles(directory: File, recursive: Boolean): Seq[File] =
+    listFiles(Seq(directory), recursive, Seq.empty)
+
+  @tailrec
+  private def listFiles(inputFiles: Seq[File], recursive: Boolean, accFiles: Seq[File]): Seq[File] = {
+    val files = inputFiles.filter(_.isFile) ++: accFiles
+    val subFiles = inputFiles.filter(_.isDirectory).flatMap(_.listFiles())
+    if (recursive && subFiles.nonEmpty) listFiles(subFiles, recursive, files)
+    else files ++: subFiles.filter(_.isFile)
+  }
+}

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
@@ -76,9 +76,9 @@ object Implicits {
     }
   }
 
-  implicit class FileArrayEnricher(files: Array[File]) {
+  implicit class FileArrayEnricher(files: Seq[File]) {
 
-    def withSuffix(suffix: String): Array[File] = {
+    def withSuffix(suffix: String): Seq[File] = {
       files.filter(_.getName.endsWith(suffix))
     }
   }

--- a/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
+++ b/src/test/java/at/makubi/maven/plugin/avrohugger/AvrohuggerGeneratorTest.java
@@ -63,13 +63,31 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         failTestIfFilesDiffer(expectedRecord, actualRecord);
     }
 
+    public void testAvrohuggerGeneratorWithSort() throws IOException {
+        Path inputDirectory = Paths.get(getBasedir()).resolve("src/test/resources/unit/avrohugger-maven-plugin");
+        Path schemaDirectory = inputDirectory.resolve("standardSchema");
+
+        Path expectedRecord = inputDirectory.resolve("expected/ARecord.scala");
+        Path expectedEnum = inputDirectory.resolve("expected/MoneyDecimal.scala");
+        Path actualRecord = outputDirectory.resolve("com/test/ARecord/ARecord.scala");
+        Path actualEnum = outputDirectory.resolve("com/test/MoneyDecimal.scala");
+
+        avrohuggerGenerator.generateScalaFiles(
+                schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), true, false,
+                SourceGenerationFormat.STANDARD, Collections.<Mapping>emptyList(),
+                Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+
+        failTestIfFilesDiffer(expectedRecord, actualRecord);
+        failTestIfFilesDiffer(expectedEnum, actualEnum);
+    }
+
     public void testAvrohuggerGeneratorRecursive() throws IOException {
         Path inputDirectory = Paths.get(getBasedir()).resolve("src/test/resources/unit/avrohugger-maven-plugin");
         Path schemaDirectory = inputDirectory.resolve("schema");
 
         Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
         Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
-        
+
         Path expectedSubRecord = inputDirectory.resolve("expected/SubRecord.scala");
         Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
 
@@ -79,4 +97,18 @@ public class AvrohuggerGeneratorTest extends AbstractMojoTestCase {
         failTestIfFilesDiffer(expectedSubRecord, actualSubRecord);
     }
 
+    public void testAvrohuggerGeneratorNotRecursive() throws IOException {
+        Path inputDirectory = Paths.get(getBasedir()).resolve("src/test/resources/unit/avrohugger-maven-plugin");
+        Path schemaDirectory = inputDirectory.resolve("schema");
+
+        Path expectedRecord = inputDirectory.resolve("expected/Record.scala");
+        Path actualRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/Record.scala");
+
+        Path actualSubRecord = outputDirectory.resolve("at/makubi/maven/plugin/model/submodel/SubRecord.scala");
+
+        avrohuggerGenerator.generateScalaFiles(schemaDirectory.toFile(), outputDirectory.toString(), new SystemStreamLog(), false, false, SourceGenerationFormat.SPECIFIC_RECORD, Collections.<Mapping>emptyList(), Collections.singletonList(new FileInclude("**", MatchSyntax.GLOB)), new TypeOverrides());
+
+        failTestIfFilesDiffer(expectedRecord, actualRecord);
+        assertFalse(actualSubRecord + " exists, but should not", actualSubRecord.toFile().exists());
+    }
 }

--- a/src/test/resources/unit/avrohugger-maven-plugin/expected/ARecord.scala
+++ b/src/test/resources/unit/avrohugger-maven-plugin/expected/ARecord.scala
@@ -1,0 +1,6 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.test.ARecord
+
+import com.test.MoneyDecimal
+
+final case class ARecord(GroupId: String = "", MediaCostCPMInUSD: Option[MoneyDecimal.Value], SupplyVendor: Option[String])

--- a/src/test/resources/unit/avrohugger-maven-plugin/expected/MoneyDecimal.scala
+++ b/src/test/resources/unit/avrohugger-maven-plugin/expected/MoneyDecimal.scala
@@ -1,0 +1,8 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.test
+
+/** Fully-qualified dependency */
+object MoneyDecimal extends Enumeration {
+  type MoneyDecimal = Value
+  val A, AA, AAA = Value
+}

--- a/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/a/ARecord.avsc
+++ b/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/a/ARecord.avsc
@@ -1,0 +1,30 @@
+{
+  "type": "record",
+  "name": "ARecord",
+  "namespace": "com.test.ARecord",
+  "fields": [
+    {
+      "name": "GroupId",
+      "type": "string",
+      "default": ""
+    },
+    {
+      "name": "MediaCostCPMInUSD",
+      "aliases": ["WinningPriceCPMInBucks"],
+      "type": [
+        "null",
+        "com.test.MoneyDecimal"
+      ],
+      "tsvIndex": 5
+    },
+    {
+      "name": "SupplyVendor",
+      "aliases": ["SupplyVendorName"],
+      "type": [
+        "null",
+        "string"
+      ],
+      "tsvIndex": 6
+    }
+  ]
+}

--- a/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/b/MoneyDecimal.avsc
+++ b/src/test/resources/unit/avrohugger-maven-plugin/standardSchema/b/MoneyDecimal.avsc
@@ -1,0 +1,7 @@
+{
+  "namespace": "com.test",
+  "name": "MoneyDecimal",
+  "type": "enum",
+  "doc": "Fully-qualified dependency",
+  "symbols" : ["A", "AA", "AAA"]
+}


### PR DESCRIPTION
Current approach for sorting process folder by folder. So that files are sorted within each folder independently so that if dependent files are in subfolder it going to fail to sort them in the right order.
This fix changes logic to first read all required files recursively and then sort them with `avrohugger-filesorter`.