### PR TITLE
Add support for type overrides in POM config for logical types of `JavaTimeInstant` and `JavaSqlTimestamp` for `LONG` type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ You can override the following variables in the plugin configuration:
     * longType
     * nullType
     * stringType
+  * Logical
+    * timestampMillisType - possible values are `JavaTimeInstant` or `JavaSqlTimestamp`
 * Defaults to no overrides
 
 #### Example

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/typeoverride/TypeOverrides.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/typeoverride/TypeOverrides.java
@@ -1,6 +1,7 @@
 package at.makubi.maven.plugin.avrohugger.typeoverride;
 
 import at.makubi.maven.plugin.avrohugger.typeoverride.complex.*;
+import at.makubi.maven.plugin.avrohugger.typeoverride.logical.AvroScalaTimestampMillisType;
 import at.makubi.maven.plugin.avrohugger.typeoverride.primitive.*;
 
 public class TypeOverrides {
@@ -21,6 +22,7 @@ public class TypeOverrides {
     private avrohugger.types.AvroScalaNumberType longType;
     private avrohugger.types.AvroScalaNullType nullType;
     private avrohugger.types.AvroScalaStringType stringType;
+    private avrohugger.types.AvroScalaTimestampMillisType timestampMillisType;
 
     public TypeOverrides() {}
 
@@ -143,5 +145,13 @@ public class TypeOverrides {
 
     public void setStringType(AvroScalaStringType stringType) {
         this.stringType = stringType.avrohuggerScalaStringType;
+    }
+
+    public avrohugger.types.AvroScalaTimestampMillisType getTimestampMillisType() {
+        return timestampMillisType;
+    }
+
+    public void setTimestampMillisType(AvroScalaTimestampMillisType timestampMillisType) {
+        this.timestampMillisType = timestampMillisType.avrohuggerScalaTimestampMillisType;
     }
 }

--- a/src/main/java/at/makubi/maven/plugin/avrohugger/typeoverride/logical/AvroScalaTimestampMillisType.java
+++ b/src/main/java/at/makubi/maven/plugin/avrohugger/typeoverride/logical/AvroScalaTimestampMillisType.java
@@ -1,0 +1,20 @@
+package at.makubi.maven.plugin.avrohugger.typeoverride.logical;
+
+
+import avrohugger.types.JavaSqlTimestamp$;
+import avrohugger.types.JavaTimeInstant$;
+
+/**
+ * https://github.com/julianpeeters/avrohugger/blob/master/avrohugger-core/src/main/scala/types/LogicalAvroScalaTypes.scala#L14-L16
+ */
+public enum AvroScalaTimestampMillisType {
+
+    JAVA_TIME_INSTANT(JavaTimeInstant$.MODULE$),
+    JAVA_SQL_TIMESTAMP(JavaSqlTimestamp$.MODULE$);
+
+    public final avrohugger.types.AvroScalaTimestampMillisType avrohuggerScalaTimestampMillisType;
+
+    AvroScalaTimestampMillisType(avrohugger.types.AvroScalaTimestampMillisType avrohuggerScalaTimestampMillisType) {
+        this.avrohuggerScalaTimestampMillisType = avrohuggerScalaTimestampMillisType;
+    }
+}

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/AvrohuggerGenerator.scala
@@ -76,6 +76,7 @@ class AvrohuggerGenerator {
       .withOptionalLongType(typeOverrides.getLongType)
       .withOptionalNullType(typeOverrides.getNullType)
       .withOptionalStringType(typeOverrides.getStringType)
+      .withOptionalTimestampMillisType(typeOverrides.getTimestampMillisType)
 
     val generator = Generator(
       format = sourceFormat,

--- a/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
+++ b/src/main/scala/at/makubi/maven/plugin/avrohugger/Implicits.scala
@@ -69,6 +69,9 @@ object Implicits {
     def withOptionalStringType(optionalString: avrohugger.types.AvroScalaStringType): AvroScalaTypes =
       nonNullOrDefault(optionalString)(string => avroScalaTypes.copy(string = string))
 
+    def withOptionalTimestampMillisType(optionalTimestampMillis: avrohugger.types.AvroScalaTimestampMillisType): AvroScalaTypes =
+      nonNullOrDefault(optionalTimestampMillis)(timestampMillis => avroScalaTypes.copy(timestampMillis = timestampMillis))
+
     private def nonNullOrDefault[T](maybeNull: T)(f: T => AvroScalaTypes): AvroScalaTypes = {
       Option(maybeNull).map { t =>
         f(t)

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/TypeOverrides.avdl
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/TypeOverrides.avdl
@@ -5,5 +5,6 @@ protocol TypeOverridesModel {
   record TypeOverridesRecord {
     string text;
     array<string> myArray;
+    timestamp_ms ts;
   }
 }

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/TypeOverridesRecord.scala
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/TypeOverridesRecord.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package at.makubi.maven.plugin.model
 
-final case class TypeOverridesRecord(text: String, myArray: Array[String])
+final case class TypeOverridesRecord(text: String, myArray: Array[String], ts: java.sql.Timestamp)

--- a/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/pom-overwrite.xml
+++ b/src/test/resources/unit/avrohugger-maven-plugin/mojo/overwrite/pom-overwrite.xml
@@ -53,6 +53,7 @@
                     </fileIncludes>
                     <typeOverrides>
                         <arrayType>SCALA_ARRAY</arrayType>
+                        <timestampMillisType>JAVA_SQL_TIMESTAMP</timestampMillisType>
                     </typeOverrides>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This type override for logic type `TimestampMillis` for LONG is supported by avrohugger already.
This code is just adding option to configure it through pom. 
Test is included.